### PR TITLE
Escape HTML in the titles

### DIFF
--- a/template.erb
+++ b/template.erb
@@ -100,7 +100,7 @@ HTML {
     <% end %>
   <div class="item">
     <!-- div class="time"><%= item[:published].strftime("%H") %>h</div -->
-    <div class="link"><a href="<%= item[:url] %>"><%= item[:title] %></a></div>
+    <div class="link"><a href="<%= item[:url] %>"><%=h item[:title] %></a></div>
     <div class="source"><span><%= item[:feed] %>&nbsp;</span></div>
   </div>
 <% 


### PR DESCRIPTION
I have seen an article with an HTML tag (<select>) which broke the display of the list, I am not Ruby expect, but this is supposed to solve it.