### PR TITLE
Add JVM Weekly feed

### DIFF
--- a/engblogs.opml
+++ b/engblogs.opml
@@ -368,6 +368,7 @@
 <outline type="rss" text="Go Programming Language" xmlUrl="https://go.dev/blog/feed.atom" htmlUrl="https://go.dev/blog/"/>
 <outline type="rss" text="Tomasz Gągor" xmlUrl="https://gagor.pro/index.xml" htmlUrl="https://gagor.pro/about/"/>
 <outline type="rss" text="Apartment 304" xmlUrl="https://blog.apartment304.com/feed.xml" htmlUrl="https://blog.apartment304.com/"/>
+<outline type="rss" text="JVM Weekly" xmlUrl="https://jvm-weekly.substack.com/feed" htmlUrl="https://www.jvm-weekly.com/"/>
 </outline>
 </body>
 </opml>


### PR DESCRIPTION
Adds [JVM Weekly](https://www.jvm-weekly.com/) - a weekly newsletter covering the Java/JVM ecosystem (Java, Kotlin, Scala, GraalVM, Quarkus, and more).

- **Feed URL:** https://jvm-weekly.substack.com/feed
- **Site URL:** https://www.jvm-weekly.com/