### PR TITLE
Add Jens Ernstberger feed

### DIFF
--- a/engblogs.opml
+++ b/engblogs.opml
@@ -368,6 +368,7 @@
 <outline type="rss" text="Go Programming Language" xmlUrl="https://go.dev/blog/feed.atom" htmlUrl="https://go.dev/blog/"/>
 <outline type="rss" text="Tomasz Gągor" xmlUrl="https://gagor.pro/index.xml" htmlUrl="https://gagor.pro/about/"/>
 <outline type="rss" text="Apartment 304" xmlUrl="https://blog.apartment304.com/feed.xml" htmlUrl="https://blog.apartment304.com/"/>
+<outline type="rss" text="Jens Ernstberger" xmlUrl="https://ernstberger.xyz/posts/index.xml" htmlUrl="https://ernstberger.xyz/posts/"/>
 <outline type="rss" text="JVM Weekly" xmlUrl="https://jvm-weekly.substack.com/feed" htmlUrl="https://www.jvm-weekly.com/"/>
 </outline>
 </body>


### PR DESCRIPTION
Hey @peterc, really like the aggregator and would love to add my own posts to the newsfeed!

Thanks in advance :)

## Summary
- add Jens Ernstberger's blog RSS feed to engblogs.opml
- use the posts-only RSS feed at https://ernstberger.xyz/posts/index.xml

## Validation
- xmllint --noout engblogs.opml
- go test ./...